### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/poms/base-parent/pom.xml
+++ b/poms/base-parent/pom.xml
@@ -51,7 +51,7 @@
     <chronicle.version>3.3.2</chronicle.version>
     <chronicle-logger.version>1.0.2</chronicle-logger.version>
     <commons-beanutils.version>1.8.3</commons-beanutils.version>
-    <commons-collections.version>3.2.1</commons-collections.version>
+    <commons-collections.version>3.2.2</commons-collections.version>
     <commons-codec.version>1.6</commons-codec.version>
     <commons-dbcp.version>1.2.2</commons-dbcp.version>
     <commons-dbcp2.version>2.0.1</commons-dbcp2.version>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That is the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
